### PR TITLE
Revert "Fix software detail page SEO and remove hardcoded github.io URLs"

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,13 +24,13 @@
     <meta name="twitter:title" content="软件下载站 - 安全可靠的软件下载平台" />
     <meta name="twitter:description" content="提供常用软件的安全下载服务，包括系统工具、开发工具、办公软件等。" />
     
-    <!-- Canonical URL (dynamically updated by JavaScript based on actual deployment URL) -->
-    <link rel="canonical" href="" />
+    <!-- Canonical URL (will be dynamically updated by JavaScript based on actual deployment URL) -->
+    <link rel="canonical" href="https://gmij.github.io/soft/" />
     
-    <!-- Language Alternates (dynamically updated by JavaScript based on actual deployment URL) -->
-    <link rel="alternate" hreflang="zh-CN" href="" />
-    <link rel="alternate" hreflang="en" href="" />
-    <link rel="alternate" hreflang="x-default" href="" />
+    <!-- Language Alternates -->
+    <link rel="alternate" hreflang="zh-CN" href="https://gmij.github.io/soft/" />
+    <link rel="alternate" hreflang="en" href="https://gmij.github.io/soft/" />
+    <link rel="alternate" hreflang="x-default" href="https://gmij.github.io/soft/" />
     
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/src/pages/SoftwareDetailPage.tsx
+++ b/src/pages/SoftwareDetailPage.tsx
@@ -53,41 +53,23 @@ const SoftwareDetailPage: React.FC = () => {
     const plainDescription = description ? stripMarkdown(description).substring(0, 160) : '';
     const isEnglish = i18n.language === 'en';
     
-    // Build keywords from software name, tags, and version
-    const tagKeywords = software.tags?.map(tag => 
-      isEnglish ? tag : t(`tags.${tag}`, { defaultValue: tag })
-    ).join(',') || '';
-    const versionInfo = latestVersion?.version || '';
-    const baseKeywords = isEnglish
-      ? `${software.name},${versionInfo},download,software,free download`
-      : `${software.name},${versionInfo},下载,软件,免费下载`;
-    const keywords = tagKeywords ? `${baseKeywords},${tagKeywords}` : baseKeywords;
-    
-    // Build more descriptive title including version
-    const versionText = versionInfo ? ` ${versionInfo}` : '';
-    const seoTitle = isEnglish 
-      ? `${software.name}${versionText} - Free Download | ${t('common.siteName')}`
-      : `${software.name}${versionText} 免费下载 - ${t('common.siteName')}`;
-    
-    // Build better description with software info
-    const tagNames = software.tags?.map(tag => 
-      isEnglish ? tag : t(`tags.${tag}`, { defaultValue: tag })
-    ).join(', ') || '';
-    const seoDescription = plainDescription || (isEnglish 
-      ? `Download ${software.name}${versionText} for free. ${tagNames ? `Category: ${tagNames}. ` : ''}Safe and fast download.`
-      : `免费下载 ${software.name}${versionText}。${tagNames ? `分类：${tagNames}。` : ''}安全快速下载。`);
-    
     updatePageMeta({
-      title: seoTitle,
-      description: seoDescription,
-      keywords: keywords,
+      title: isEnglish 
+        ? `${software.name} Download - Software Download`
+        : `${software.name} 下载 - 软件下载站`,
+      description: plainDescription || (isEnglish 
+        ? `Download ${software.name} - latest version available for free download.`
+        : `下载 ${software.name} - 最新版本免费下载。`),
+      keywords: isEnglish
+        ? `${software.name},download,software,free download`
+        : `${software.name},下载,软件,免费下载`,
       ogTitle: isEnglish 
-        ? `Download ${software.name}${versionText}`
-        : `下载 ${software.name}${versionText}`,
-      ogDescription: seoDescription,
-      canonicalPath: `software/${encodeURIComponent(software.name)}`
+        ? `Download ${software.name}`
+        : `下载 ${software.name}`,
+      ogDescription: plainDescription,
+      canonicalPath: `#/software/${encodeURIComponent(software.name)}`
     });
-  }, [software, i18n.language, t]);
+  }, [software, i18n.language]);
 
   useEffect(() => {
     if (!name) return;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -108,23 +108,15 @@ export function updatePageMeta(options: {
     twitterDescription.setAttribute('content', options.ogDescription || options.description);
   }
   
-  // Use the current origin and base path for URLs
-  const baseUrl = `${window.location.origin}${import.meta.env.BASE_URL}`;
-  
-  // Update canonical URL
+  // Update canonical URL using base URL from window location
   if (options.canonicalPath !== undefined) {
     const canonical = document.querySelector('link[rel="canonical"]');
     if (canonical) {
+      // Use the current origin and base path for canonical URL
+      const baseUrl = `${window.location.origin}${import.meta.env.BASE_URL}`;
       canonical.setAttribute('href', `${baseUrl}${options.canonicalPath}`);
     }
   }
-  
-  // Update hreflang links
-  const hreflangLinks = document.querySelectorAll('link[rel="alternate"][hreflang]');
-  hreflangLinks.forEach((link) => {
-    const currentPath = options.canonicalPath !== undefined ? options.canonicalPath : '';
-    link.setAttribute('href', `${baseUrl}${currentPath}`);
-  });
 }
 
 // 格式化文件大小


### PR DESCRIPTION
Reverts gmij/soft#18

看了下， github.io的内容， 已经没有了。 

但是， 软件详情的seo依然没有生成。 你认真检查 一下。

另外 ， 是否可以移除google的字体加载。 

